### PR TITLE
Fix property formatting: CSS snippets.md

### DIFF
--- a/en/Extending Obsidian/CSS snippets.md
+++ b/en/Extending Obsidian/CSS snippets.md
@@ -74,7 +74,8 @@ It has a host of [CSS variables](https://docs.obsidian.md/Reference/CSS+variable
 > 
 > **YAML/Properties**:
 > ```yaml
-> cssclasses: no-inline
+> cssclasses:
+>  - homepage
 > ```
 > 
 > This hides the inline title from any note with this property and value.


### PR DESCRIPTION
I just realized I forgot to list format cssclasses. sailkite would get mad. and obsidian 1.9.